### PR TITLE
[47037] use virks definition of active

### DIFF
--- a/virk_dk/templates/get_org_info_from_cvr.j2
+++ b/virk_dk/templates/get_org_info_from_cvr.j2
@@ -4,21 +4,63 @@
       "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
       "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse",
       "Vrvirksomhed.virksomhedMetadata.nyesteHovedbranche",
-      "Vrvirksomhed.virksomhedMetadata.sammensatStatus",
-      "Vrvirksomhed.livsforloeb.periode.gyldigTil"
+      "Vrvirksomhed.virksomhedMetadata.sammensatStatus"
    ],
    "query":{
       "bool":{
-         "must":{
-            "term":{
-               "Vrvirksomhed.cvrNummer":"{{cvr_number}}"
+         "must":[
+            {
+               "term":{
+                  "Vrvirksomhed.cvrNummer":"{{cvr_number}}"
+               }
+            },
+            {
+               "bool":{
+                  "should":[
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"NORMAL"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"Aktiv"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERTVANGSOPLØSNING"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERFRIVILLIGLIKVIDATION"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERKONKURS"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERREKONSTRUKION"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERREASSUMERING"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"OMDANNET"
+                        }
+                     }
+                  ]
+               }
             }
-         },
-         "must_not":{
-            "exists":{
-               "field":"Vrvirksomhed.livsforloeb.periode.gyldigTil"
-            }
-         }
+         ]
       }
    },
    "size":1

--- a/virk_dk/templates/get_org_info_from_cvr_p_number_or_name.j2
+++ b/virk_dk/templates/get_org_info_from_cvr_p_number_or_name.j2
@@ -1,31 +1,72 @@
 {
-"_source":[
+   "_source":[
       "Vrvirksomhed.cvrNummer",
       "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
       "Vrvirksomhed.virksomhedMetadata.nyesteBeliggenhedsadresse",
       "Vrvirksomhed.virksomhedMetadata.nyesteHovedbranche",
       "Vrvirksomhed.virksomhedMetadata.sammensatStatus",
-      "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
-      "Vrvirksomhed.livsforloeb.periode.gyldigTil"
+      "Vrvirksomhed.virksomhedMetadata.penheder.pNummer"
    ],
    "query":{
       "bool":{
-         "must":{
-            "query_string":{
-               "fields":[
-                  "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
-                  "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
-                  "Vrvirksomhed.cvrNummer"
-               ],
-               "query": "(Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn:{{ search_term }} OR Vrvirksomhed.penheder.pNummer:{{ search_term }} OR Vrvirksomhed.cvrNummer:{{ search_term }})"
+         "must":[
+            {
+               "query_string":{
+                  "fields":[
+                     "Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn",
+                     "Vrvirksomhed.virksomhedMetadata.penheder.pNummer",
+                     "Vrvirksomhed.cvrNummer"
+                  ],
+                  "query":"(Vrvirksomhed.virksomhedMetadata.nyesteNavn.navn:{{ search_term }} OR Vrvirksomhed.penheder.pNummer:{{ search_term }} OR Vrvirksomhed.cvrNummer:{{ search_term }})"
+               }
+            },
+            {
+               "bool":{
+                  "should":[
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"NORMAL"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"Aktiv"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERTVANGSOPLØSNING"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERFRIVILLIGLIKVIDATION"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERKONKURS"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERREKONSTRUKION"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"UNDERREASSUMERING"
+                        }
+                     },
+                     {
+                        "term":{
+                           "Vrvirksomhed.virksomhedMetadata.sammensatStatus":"OMDANNET"
+                        }
+                     }
+                  ]
+               }
             }
-         },
-
-         "must_not":{
-            "exists":{
-               "field":"Vrvirksomhed.livsforloeb.periode.gyldigTil"
-            }
-         }
+         ]
       }
    }
 }


### PR DESCRIPTION
Even though the documentation from Virk mention using "Vrvirksomhed.livsforloeb.periode.gyldigTil" for filtering active companies, the site (https://datacvr.virk.dk/data/visninger?soeg=&virksomhedsstatus=aktive_virksomhedsstatus&type=virksomhed) uses the "Vrvirksomhed.virksomhedMetadata.sammensatStatus" so i guess we should use that as well.